### PR TITLE
Use docker-buildx to build multi-platform images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,10 +23,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-      - name: Run tests
-        run: make
+      - name: Test build
+        run: make build
 
   # Push image to GitHub Packages.
   # See also https://docs.docker.com/docker-hub/builds/
@@ -42,18 +43,8 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Build app
-        run: make build
-
-      - name: Build image
-        run: docker build . --file Dockerfile --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"
-
-      - name: Log into registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-
-      - name: Push image
+      - name: Set up environment
+        id: setup
         run: |
           IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
 
@@ -69,8 +60,40 @@ jobs:
           # Use Docker `latest` tag convention
           [ "$VERSION" == "master" ] && VERSION=latest
 
-          echo IMAGE_ID=$IMAGE_ID
-          echo VERSION=$VERSION
+          TAGS="${IMAGE_ID}:${VERSION}"
 
-          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
-          docker push $IMAGE_ID:$VERSION
+          echo ::set-output name=tags::${TAGS}
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          install: true
+
+      - name: List available platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.setup.outputs.tags }}
+          push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,13 @@
+FROM golang:1.17 AS builder
+
+WORKDIR /go/src/github.com/rhobs/prometheus-example-app
+COPY . /go/src/github.com/rhobs/prometheus-example-app
+
+RUN make build
+
 FROM quay.io/prometheus/busybox:latest
 
-ADD prometheus-example-app /bin/prometheus-example-app
+COPY --from=builder /go/src/github.com/rhobs/prometheus-example-app/prometheus-example-app \
+  /bin/prometheus-example-app
 
 ENTRYPOINT ["/bin/prometheus-example-app"]

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ LDFLAGS="-X main.appVersion=$(VERSION)"
 
 .PHONY : all build image
 
-all: build image
+all: build
 
 build:
 	CGO_ENABLED=0 go build -ldflags=$(LDFLAGS) -o prometheus-example-app --installsuffix cgo main.go
 
-image: build
-	docker build -t ghcr.io/rhobs/$(IMAGE_NAME):$(VERSION) .
+image:
+	docker build -t "ghcr.io/rhobs/$(IMAGE_NAME):$(VERSION)" .


### PR DESCRIPTION
Updating the GitHub workflow and the Dockerfile to allow building arm64 images in addition to amd64.